### PR TITLE
Avoid confusion by exiting if the release is not found

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 
 A Helm plugin to get debug information about the Kubernetes resources created by a release. The output is useful for troubleshooting in a CI / CD environment where it is valuable to capture the state of a release following a failure. The following information will be output to the output directory.
 
-For best results, it is recommended that your Helm chart specifies a metadata.namespace value for each resource (even if it just the chart default of `{{ .Release.Namespace }}`). The plugin uses the output of `helm get manifest` and `helm get hooks` to determine the resources available for log collection.
-
 * Environment variables
 * Helm release list
 * Helm user values
@@ -13,6 +11,8 @@ For best results, it is recommended that your Helm chart specifies a metadata.na
 * Kubernetes resource list
 * Kubernetes describe of each pod
 * Kubernetes logs for each container
+
+For best results, it is recommended that your Helm chart specifies a metadata.namespace value for each resource (even if it just the chart default of `{{ .Release.Namespace }}`). The plugin uses the output of `helm get manifest` and `helm get hooks` to determine the resources available for log collection.
 
 ## Requirements
 

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: release-logs
-version: 0.4.0
+version: 0.5.0
 usage: Get debug info about resources created by a release.
 description: A Helm plugin to get debug information about the Kubernetes resources creaeted by a release.
 command: $HELM_PLUGIN_DIR/release-logs.sh

--- a/release-logs.sh
+++ b/release-logs.sh
@@ -96,7 +96,7 @@ echo "Saving Helm release list ..."
 ${helm} ls > "${dir}/releases.log" || true
 
 echo "Checking for Helm release ${release} ..."
-if ! ${helm} ls -q | grep "${release}"; then
+if ! ${helm} ls -q | grep -q "${release}"; then
   echo "Release ${release} not found. This may mean the namespace is incorrect or the Helm install or upgrade failed."
   exit 0
 fi

--- a/release-logs.sh
+++ b/release-logs.sh
@@ -95,6 +95,12 @@ env | grep -v PASS | sort > "${dir}/env"
 echo "Saving Helm release list ..."
 ${helm} ls > "${dir}/releases.log" || true
 
+echo "Checking for Helm release ${release} ..."
+if ! ${helm} ls -q | grep "${release}"; then
+  echo "Release ${release} not found. This may mean the namespace is incorrect or the Helm install or upgrade failed."
+  exit 0
+fi
+
 echo "Saving Helm user values ..."
 ${helm} get values "${release}" > "${dir}/values-user.yaml" || true
 


### PR DESCRIPTION
# Testing

Install 0.4.0
```
~/src/github/jzbruno/helm-release-logs $ helm plugin install https://github.com/jzbruno/helm-release-logs/
Installed plugin: release-logs
~/src/github/jzbruno/helm-release-logs $ helm plugin ls
NAME        	VERSION	DESCRIPTION
diff        	3.1.3  	Preview helm upgrade changes as a diff
kubeval     	0.13.0 	"Validate Helm charts against the Kubernetes schemas"
release-logs	0.4.0  	A Helm plugin to get debug information about the Kubernetes resources creaeted by a release.
```
With missing release
```
~/src/github/jzbruno/helm-release-logs $ helm release-logs hello -n default
Gathering info for release hello in namespace default ...
Saving environment variables ...
Saving Helm release list ...
Saving Helm user values ...
Error: release: not found
Saving Helm computed values ...
Error: release: not found
Saving Kubernetes resource list ...
Error: release: not found
Error: release: not found
Gathering resources for log collection
Context "docker-desktop" modified.
Error: release: not found
Error: release: not found
```
Install 0.5.0 with fixes
```
~/src/github/jzbruno/helm-release-logs $ helm plugin remove release-logs
Uninstalled plugin: release-logs
~/src/github/jzbruno/helm-release-logs $ helm plugin install .
Installed plugin: release-logs
~/src/github/jzbruno/helm-release-logs $ helm plugin ls
NAME        	VERSION	DESCRIPTION
diff        	3.1.3  	Preview helm upgrade changes as a diff
kubeval     	0.13.0 	"Validate Helm charts against the Kubernetes schemas"
release-logs	0.5.0  	A Helm plugin to get debug information about the Kubernetes resources creaeted by a release.
```
With missing release
```
~/src/github/jzbruno/helm-release-logs $ helm release-logs hello -n default
Gathering info for release hello in namespace default ...
Saving environment variables ...
Saving Helm release list ...
Checking for Helm release hello ...
Release hello not found. This may mean the namespace is incorrect or the Helm install or upgrade failed.
```
With existing release
```
~/src/github/jzbruno/helm-release-logs $ helm release-logs hello -n hello
Gathering info for release hello in namespace hello ...
Saving environment variables ...
Saving Helm release list ...
Checking for Helm release hello ...
Saving Helm user values ...
Saving Helm computed values ...
Saving Kubernetes resource list ...
Gathering resources for log collection
Context "docker-desktop" modified.
Gathering logs from pods in deployment/hello/hello
Saving describe output for pod/hello/hello-77bd85f78f-w7nv7
 > Saving logs for container hello in pod hello/hello-77bd85f78f-w7nv7
```